### PR TITLE
Add manager and intents

### DIFF
--- a/service/src/main/java/com/derpgroup/derpwizard/manager/DerpWizardManager.java
+++ b/service/src/main/java/com/derpgroup/derpwizard/manager/DerpWizardManager.java
@@ -1,0 +1,29 @@
+package com.derpgroup.derpwizard.manager;
+
+import com.derpgroup.derpwizard.voice.model.VoiceInput;
+
+public class DerpWizardManager {
+
+  public String handleRequest(VoiceInput vi){
+    
+    DerpWizardRequestTypes requestType = vi.getRequestName(DerpWizardRequestTypes.class);
+    
+    switch(requestType){
+    case HELLO:
+      return doHelloRequest();
+    case HELP:
+      return doHelpRequest();
+    default:
+      return "Unknown request type '" + requestType + "'.";
+    }
+  }
+
+  private String doHelpRequest() {
+    return "<speak><p><s>I'd love to help, but I don't have any help topics programmed yet.</s></p></speak>";
+  }
+
+  private String doHelloRequest() {
+    return "<speak><p><s>Hi. This is DerpWizard.</s></p></speak>";
+  }
+  
+}

--- a/service/src/main/java/com/derpgroup/derpwizard/manager/DerpWizardRequestTypes.java
+++ b/service/src/main/java/com/derpgroup/derpwizard/manager/DerpWizardRequestTypes.java
@@ -1,0 +1,6 @@
+package com.derpgroup.derpwizard.manager;
+
+public enum DerpWizardRequestTypes {
+  HELLO,
+  HELP
+}

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/AlexaInput.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/AlexaInput.java
@@ -20,20 +20,37 @@
 
 package com.derpgroup.derpwizard.voice.model;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 
+
+import com.amazon.speech.slu.Intent;
 import com.amazon.speech.slu.Slot;
 import com.amazon.speech.speechlet.IntentRequest;
 
 class AlexaInput implements VoiceInput {
   private IntentRequest request;
-
+  private Map<String,Object> metadata;
+  
   public AlexaInput(Object object) {
-    if (!(object instanceof IntentRequest)) {
-      throw new IllegalArgumentException("Argument is not an instance of IntentRequest: " + object);
+    this(object, null);
+  }
+
+  @SuppressWarnings("unchecked")
+  public AlexaInput(Object request, Object metadata) {
+    if (!(request instanceof IntentRequest)) {
+      throw new IllegalArgumentException("First argument is not an instance of IntentRequest: " + request);
     }
 
-    request = (IntentRequest) object;
+    this.request = (IntentRequest) request;
+    
+    if(metadata != null){
+      if (!(metadata instanceof Map<?,?>)) {
+        throw new IllegalArgumentException("Second argument is not an instance of Map<?,?>: " + metadata);
+      }
+      this.metadata = (HashMap<String, Object>) metadata;
+    }
   }
 
   @Override
@@ -49,5 +66,31 @@ class AlexaInput implements VoiceInput {
     }
 
     return buffer.toString();
+  }
+
+  @Override
+  public Map<String, String> getParameters() {
+    Map<String,String> slots = new HashMap<String,String>();
+    Intent intent = request.getIntent();
+    if(intent.getSlots() == null){
+      return slots;
+    }
+    
+    for(Entry<String,Slot> entry : intent.getSlots().entrySet()){
+      slots.put(entry.getKey(), entry.getValue().getValue());
+    }
+    
+    return slots;
+  }
+
+  //TODO: We should put some code in here to map built in AMAZON intents to other request types
+  @Override
+  public <E extends Enum<E>> E getRequestName(Class<E> enumClass) {
+    return (E)(Enum.valueOf(enumClass, request.getIntent().getName()));
+  }
+
+  @Override
+  public Map<String, Object> getMetadata() {
+    return metadata;
   }
 }

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/AlexaInput.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/AlexaInput.java
@@ -49,7 +49,7 @@ class AlexaInput implements VoiceInput {
       if (!(metadata instanceof Map<?,?>)) {
         throw new IllegalArgumentException("Second argument is not an instance of Map<?,?>: " + metadata);
       }
-      this.metadata = (HashMap<String, Object>) metadata;
+      this.metadata = (Map<String, Object>) metadata;
     }
   }
 

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceInput.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceInput.java
@@ -20,6 +20,8 @@
 
 package com.derpgroup.derpwizard.voice.model;
 
+import java.util.Map;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -36,4 +38,26 @@ public interface VoiceInput {
    * @return The message in plain text, never null
    */
   @NonNull String getMessage();
+  
+  /**
+   * A map of key-value pairs sent as input along with the request
+   * 
+   * @return A map of parameters.  Can be empty, but not null
+   */
+  @NonNull Map<String,String> getParameters();
+  
+  /**
+   * Get the request name of the request
+   * 
+   * @param enumClass the enum describing possible request names
+   * @return The Enum value representation of the request name
+   */
+  @NonNull <E extends Enum<E>> E getRequestName(Class<E> enumClass);
+  
+  /**
+   * Get all pieces of metadata associated with the request
+   * 
+   * @return all associated metadata
+   */
+  Map<String,Object> getMetadata();
 }

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceMessageFactory.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceMessageFactory.java
@@ -74,6 +74,29 @@ public class VoiceMessageFactory {
   }
 
   /**
+   * Builds a wrapper around the user's voice request.
+   *
+   * @param request
+   *          The request object, not null
+   * @param metadata
+   *          Metadata associated with the request
+   * @param type
+   *          The voice interface type that sent the request, not null
+   * @return A VoiceInput wrapper, never null
+   */
+  public static @NonNull VoiceInput buildInputMessageWithMetadata(@NonNull Object request, @NonNull Object metadata, @NonNull InterfaceType type) {
+    if (!INPUT_MAP.containsKey(type)) {
+      throw new IllegalArgumentException("Invalid type: " + type);
+    }
+
+    try {
+      return (VoiceInput) INPUT_MAP.get(type).getConstructor(Object.class, Object.class).newInstance(request, metadata);
+    } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+      throw new UnsupportedOperationException("Failed to build instance", e);
+    }
+  }
+
+  /**
    * Builds a user response wrapper around an SsmlDocument.
    *
    * @param document

--- a/voice-interface/src/test/java/com/derpgroup/derpwizard/voice/model/AlexaIntentInputTest.java
+++ b/voice-interface/src/test/java/com/derpgroup/derpwizard/voice/model/AlexaIntentInputTest.java
@@ -1,0 +1,92 @@
+package com.derpgroup.derpwizard.voice.model;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+import com.amazon.speech.slu.Intent;
+import com.amazon.speech.slu.Slot;
+import com.amazon.speech.speechlet.IntentRequest;
+import com.amazon.speech.speechlet.LaunchRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AlexaIntentInputTest {
+
+  @Mock IntentRequest intentRequest;
+  Intent intent;
+  
+  @Before
+  public void setup(){
+    intent = Intent.builder().withName("TESTVALUE").withSlots(Collections.emptyMap()).build();
+    when(intentRequest.getIntent()).thenReturn(intent);
+  }
+  
+  @Test(expected = IllegalArgumentException.class)
+  public void testBadRequestType_intent(){
+    new AlexaInput(LaunchRequest.builder().withRequestId("123").build());
+  }
+  
+  @Test(expected = IllegalArgumentException.class)
+  public void testBadRequestType_metadata(){
+    new AlexaInput(IntentRequest.builder().withRequestId("123").build(),Collections.emptyList());
+  }
+  
+  @Test
+  public void testGetRequestName(){
+
+    VoiceInput vi = new AlexaInput(intentRequest);
+    assertEquals(AlexaIntentEnum.TESTVALUE,vi.getRequestName(AlexaIntentEnum.class));
+  }
+  
+  @Test
+  public void testGetParameters(){
+    Map<String, Slot> slots = new LinkedHashMap<String,Slot>();
+    slots.put("foo",Slot.builder().withName("foo").withValue("fooValue").build());
+    slots.put("bar",Slot.builder().withName("bar").withValue("barValue").build());
+    intent = Intent.builder().withName("TESTVALUE").withSlots(slots).build();
+
+    when(intentRequest.getIntent()).thenReturn(intent);
+    
+    VoiceInput vi = new AlexaInput(intentRequest);
+    assertNotNull(vi.getParameters());
+    assertEquals(slots.size(), vi.getParameters().size());
+  }
+  
+  @Test
+  public void testGetMetadata(){
+    Map<String, Object> metadata = new LinkedHashMap<String, Object>();
+    metadata.put("foo", "fooValue");
+    metadata.put("bar", new Integer(123));
+    
+    VoiceInput vi = new AlexaInput(intentRequest, metadata);
+    assertNotNull(vi.getMetadata());
+    assertNotNull(vi.getMetadata().get("foo"));
+    assertNotNull(vi.getMetadata().get("bar"));
+    assertEquals(vi.getMetadata().get("foo"),metadata.get("foo"));
+    assertEquals(vi.getMetadata().get("bar"),metadata.get("bar"));
+  }
+  
+  @Test
+  public void testGetMetadata_null(){    
+    VoiceInput vi = new AlexaInput(intentRequest);
+    assertNull(vi.getMetadata());
+    
+    vi = new AlexaInput(intentRequest, null);
+    assertNull(vi.getMetadata());    
+  }
+  
+  public enum AlexaIntentEnum{
+    TESTVALUE
+  }
+}


### PR DESCRIPTION
This branch was about adding the intent/requestname layer to the boilerplate code.  It does a few things:

-Adds additional pieces of request data to the VoiceInput interface
-Adds a super basic manager class
-Modifies the message factory to take in metadata
-Links up AlexaResource with the manager

There's still additional work to be done in the boilerplate in terms of Error handling, showing how a DAO is used, and building the output in a generic way, but those can be added on piecemeal later.
