### PR TITLE
Restrict metadata to only JSON types

### DIFF
--- a/voice-interface/pom.xml
+++ b/voice-interface/pom.xml
@@ -14,6 +14,12 @@
       <artifactId>alexa-skills-kit</artifactId>
       <version>1.1</version>
     </dependency>
+    <dependency>
+      <groupId>net.sf.json-lib</groupId>
+      <artifactId>json-lib</artifactId>
+      <classifier>jdk15</classifier>
+      <version>2.4</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/AlexaInput.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/AlexaInput.java
@@ -25,6 +25,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import net.sf.json.JSONObject;
+
 import com.amazon.speech.slu.Slot;
 import com.amazon.speech.speechlet.IntentRequest;
 import com.amazon.speech.speechlet.LaunchRequest;
@@ -33,13 +35,13 @@ import com.amazon.speech.speechlet.SpeechletRequest;
 
 class AlexaInput implements VoiceInput {
   private SpeechletRequest request;
-  private Map<String, Object> metadata = Collections.emptyMap();
+  private JSONObject metadata = new JSONObject();
 
   public AlexaInput(Object object) {
     this(object, null);
   }
 
-  public AlexaInput(Object object, Map<String, Object> metadata) {
+  public AlexaInput(Object object, JSONObject metadata) {
     if (!(object instanceof SpeechletRequest)) {
       throw new IllegalArgumentException("Argument is not an instance of SpeechletRequest: " + object);
     }
@@ -94,7 +96,7 @@ class AlexaInput implements VoiceInput {
   }
 
   @Override
-  public Map<String, Object> getMetadata() {
-    return Collections.unmodifiableMap(metadata);
+  public JSONObject getMetadata() {
+    return metadata;
   }
 }

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceInput.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceInput.java
@@ -22,6 +22,8 @@ package com.derpgroup.derpwizard.voice.model;
 
 import java.util.Map;
 
+import net.sf.json.JSONObject;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -76,7 +78,7 @@ public interface VoiceInput {
    * 
    * @return The associated metadata, never null
    */
-  @NonNull Map<String, Object> getMetadata();
+  @NonNull JSONObject getMetadata();
 
   /**
    * Get the message type with respect to a conversation flow.

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceMessageFactory.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceMessageFactory.java
@@ -24,6 +24,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 
+import net.sf.json.JSONObject;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -84,13 +86,13 @@ public class VoiceMessageFactory {
    *          The voice interface type that sent the request, not null
    * @return A VoiceInput wrapper, never null
    */
-  public static @NonNull VoiceInput buildInputMessage(@NonNull Object request, @NonNull Map<String, Object> metadata, @NonNull InterfaceType type) {
+  public static @NonNull VoiceInput buildInputMessage(@NonNull Object request, @NonNull JSONObject metadata, @NonNull InterfaceType type) {
     if (!INPUT_MAP.containsKey(type)) {
       throw new IllegalArgumentException("Invalid type: " + type);
     }
 
     try {
-      return (VoiceInput) INPUT_MAP.get(type).getConstructor(Object.class, Map.class).newInstance(request, metadata);
+      return (VoiceInput) INPUT_MAP.get(type).getConstructor(Object.class, JSONObject.class).newInstance(request, metadata);
     } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
       throw new UnsupportedOperationException("Failed to build instance", e);
     }

--- a/voice-interface/src/test/java/com/derpgroup/derpwizard/voice/model/AlexaInputTest.java
+++ b/voice-interface/src/test/java/com/derpgroup/derpwizard/voice/model/AlexaInputTest.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import net.sf.json.JSONObject;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -98,9 +100,9 @@ public class AlexaInputTest {
 
   @Test
   public void constructorWithMetadata(){
-    Map<String, Object> metadata = new LinkedHashMap<String, Object>();
+    JSONObject metadata = new JSONObject();
     metadata.put("foo", "fooValue");
-    metadata.put("bar", new Integer(123));
+    metadata.put("bar", 123);
 
     VoiceInput vi = new AlexaInput(intentRequest, metadata);
     assertNotNull(vi.getMetadata());


### PR DESCRIPTION
To simplify the number of `instanceof` calls we need to make when pulling data out of the metadata.
