### PR TITLE
Conversation history

### DIFF
--- a/service/src/main/java/com/derpgroup/derpwizard/manager/AbstractManager.java
+++ b/service/src/main/java/com/derpgroup/derpwizard/manager/AbstractManager.java
@@ -20,7 +20,6 @@
 
 package com.derpgroup.derpwizard.manager;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -31,7 +30,7 @@ import com.derpgroup.derpwizard.voice.model.CommonMetadata;
 import com.derpgroup.derpwizard.voice.model.ConversationHistoryEntry;
 import com.derpgroup.derpwizard.voice.model.SsmlDocumentBuilder;
 import com.derpgroup.derpwizard.voice.model.VoiceInput;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -88,15 +87,10 @@ public abstract class AbstractManager {
     if(conversationHistory == null){
       conversationHistory = new ArrayList<ConversationHistoryEntry>();
     }
-    CommonMetadata metadataClone = null;
-    try {
-      ObjectMapper mapper = new ObjectMapper();
-      mapper.registerModule(mapperModule);
-      String metadataString = mapper.writeValueAsString(metadata);
-      metadataClone = mapper.readValue(metadataString, CommonMetadata.class);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(mapperModule);
+    CommonMetadata metadataClone = mapper.convertValue(metadata, new TypeReference<CommonMetadata>(){});
     
     ConversationHistoryEntry entry = new ConversationHistoryEntry();
     entry.setMessageMap(new LinkedHashMap<String,String>(voiceInput.getMessageAsMap()));

--- a/service/src/main/java/com/derpgroup/derpwizard/manager/AbstractManager.java
+++ b/service/src/main/java/com/derpgroup/derpwizard/manager/AbstractManager.java
@@ -20,10 +20,20 @@
 
 package com.derpgroup.derpwizard.manager;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import com.derpgroup.derpwizard.voice.model.CommonMetadata;
+import com.derpgroup.derpwizard.voice.model.ConversationHistoryEntry;
 import com.derpgroup.derpwizard.voice.model.SsmlDocumentBuilder;
 import com.derpgroup.derpwizard.voice.model.VoiceInput;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 /**
  * Base class for message dispatchers.
@@ -32,7 +42,13 @@ import com.derpgroup.derpwizard.voice.model.VoiceInput;
  * @since 0.0.1
  */
 public abstract class AbstractManager {
+  
+  protected Module mapperModule;
 
+  public AbstractManager(){
+    mapperModule = new SimpleModule();
+  }
+  
   /**
    * Message dispatcher.
    *
@@ -42,6 +58,7 @@ public abstract class AbstractManager {
    *          The document builder to append messages to, not null
    */
   public void handleRequest(@NonNull VoiceInput voiceInput, @NonNull SsmlDocumentBuilder builder) {
+    appendToConversationHistory(voiceInput);
     switch (voiceInput.getMessageType()) {
       case START_OF_CONVERSATION:
         doHelloRequest(voiceInput, builder);
@@ -64,6 +81,32 @@ public abstract class AbstractManager {
     }
   }
 
+  private void appendToConversationHistory(@NonNull VoiceInput voiceInput) {
+    CommonMetadata metadata = voiceInput.getMetadata();
+    List<ConversationHistoryEntry> conversationHistory = metadata.getConversationHistory();
+    if(conversationHistory == null){
+      conversationHistory = new ArrayList<ConversationHistoryEntry>();
+    }
+    CommonMetadata metadataClone = null;
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      mapper.registerModule(mapperModule);
+      String metadataString = mapper.writeValueAsString(metadata);
+      metadataClone = mapper.readValue(metadataString, CommonMetadata.class);
+      metadataClone.setConversationHistory(null);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    
+    ConversationHistoryEntry entry = new ConversationHistoryEntry();
+    entry.setMessageMap(voiceInput.getMessageAsMap());
+    entry.setMessageSubject(voiceInput.getMessageSubject());
+    entry.setMetadata(metadataClone);
+    
+    conversationHistory.add(entry);
+    metadata.setConversationHistory(conversationHistory); //this is only needed in case it was null coming in
+  }
+
   protected abstract void doHelpRequest(VoiceInput voiceInput, SsmlDocumentBuilder builder);
 
   protected abstract void doHelloRequest(VoiceInput voiceInput, SsmlDocumentBuilder builder);
@@ -75,4 +118,5 @@ public abstract class AbstractManager {
   protected abstract void doStopRequest(VoiceInput voiceInput, SsmlDocumentBuilder builder);
 
   protected abstract void doConversationRequest(VoiceInput voiceInput, SsmlDocumentBuilder builder);
+  
 }

--- a/service/src/main/java/com/derpgroup/derpwizard/manager/AbstractManager.java
+++ b/service/src/main/java/com/derpgroup/derpwizard/manager/AbstractManager.java
@@ -22,6 +22,7 @@ package com.derpgroup.derpwizard.manager;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -93,13 +94,12 @@ public abstract class AbstractManager {
       mapper.registerModule(mapperModule);
       String metadataString = mapper.writeValueAsString(metadata);
       metadataClone = mapper.readValue(metadataString, CommonMetadata.class);
-      metadataClone.setConversationHistory(null);
     } catch (IOException e) {
       e.printStackTrace();
     }
     
     ConversationHistoryEntry entry = new ConversationHistoryEntry();
-    entry.setMessageMap(voiceInput.getMessageAsMap());
+    entry.setMessageMap(new LinkedHashMap<String,String>(voiceInput.getMessageAsMap()));
     entry.setMessageSubject(voiceInput.getMessageSubject());
     entry.setMetadata(metadataClone);
     

--- a/voice-interface/pom.xml
+++ b/voice-interface/pom.xml
@@ -15,12 +15,6 @@
       <version>1.1</version>
     </dependency>
     <dependency>
-      <groupId>net.sf.json-lib</groupId>
-      <artifactId>json-lib</artifactId>
-      <classifier>jdk15</classifier>
-      <version>2.4</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <version>2.5.4</version>

--- a/voice-interface/pom.xml
+++ b/voice-interface/pom.xml
@@ -20,6 +20,11 @@
       <classifier>jdk15</classifier>
       <version>2.4</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.5.4</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/AlexaInput.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/AlexaInput.java
@@ -25,8 +25,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import net.sf.json.JSONObject;
-
 import com.amazon.speech.slu.Slot;
 import com.amazon.speech.speechlet.IntentRequest;
 import com.amazon.speech.speechlet.LaunchRequest;
@@ -35,13 +33,13 @@ import com.amazon.speech.speechlet.SpeechletRequest;
 
 class AlexaInput implements VoiceInput {
   private SpeechletRequest request;
-  private JSONObject metadata = new JSONObject();
+  private CommonMetadata metadata = new CommonMetadata();
 
   public AlexaInput(Object object) {
     this(object, null);
   }
 
-  public AlexaInput(Object object, JSONObject metadata) {
+  public AlexaInput(Object object, CommonMetadata metadata) {
     if (!(object instanceof SpeechletRequest)) {
       throw new IllegalArgumentException("Argument is not an instance of SpeechletRequest: " + object);
     }
@@ -107,7 +105,7 @@ class AlexaInput implements VoiceInput {
   }
 
   @Override
-  public JSONObject getMetadata() {
+  public CommonMetadata getMetadata() {
     return metadata;
   }
 }

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/CommonMetadata.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/CommonMetadata.java
@@ -1,0 +1,16 @@
+package com.derpgroup.derpwizard.voice.model;
+
+import java.util.Map;
+
+public class CommonMetadata {
+
+  private Map<String,Object> conversationHistory;
+
+  public Map<String, Object> getConversationHistory() {
+    return conversationHistory;
+  }
+
+  public void setConversationHistory(Map<String, Object> conversationHistory) {
+    this.conversationHistory = conversationHistory;
+  }
+}

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/CommonMetadata.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/CommonMetadata.java
@@ -1,16 +1,16 @@
 package com.derpgroup.derpwizard.voice.model;
 
-import java.util.Map;
+import java.util.List;
 
 public class CommonMetadata {
 
-  private Map<String,Object> conversationHistory;
+  private List<ConversationHistoryEntry> conversationHistory;
 
-  public Map<String, Object> getConversationHistory() {
+  public List<ConversationHistoryEntry> getConversationHistory() {
     return conversationHistory;
   }
 
-  public void setConversationHistory(Map<String, Object> conversationHistory) {
+  public void setConversationHistory(List<ConversationHistoryEntry> conversationHistory) {
     this.conversationHistory = conversationHistory;
   }
 }

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/ConversationHistoryEntry.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/ConversationHistoryEntry.java
@@ -1,0 +1,37 @@
+package com.derpgroup.derpwizard.voice.model;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+public class ConversationHistoryEntry {
+
+  @JsonIgnoreProperties({ "conversationHistory" })
+  private CommonMetadata metadata;
+  private Map<String,String> messageMap;
+  private String messageSubject;
+  
+  public CommonMetadata getMetadata() {
+    return metadata;
+  }
+  
+  public void setMetadata(CommonMetadata metadata) {
+    this.metadata = metadata;
+  }
+
+  public Map<String, String> getMessageMap() {
+    return messageMap;
+  }
+
+  public void setMessageMap(Map<String, String> messageMap) {
+    this.messageMap = messageMap;
+  }
+
+  public String getMessageSubject() {
+    return messageSubject;
+  }
+
+  public void setMessageSubject(String messageSubject) {
+    this.messageSubject = messageSubject;
+  }
+}

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/SsmlDocumentBuilder.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/SsmlDocumentBuilder.java
@@ -82,6 +82,7 @@ public class SsmlDocumentBuilder {
   private Set<String> ignoreTags;
   private List<List<StringBuilder>> paragraphs;
   private int index = 0;
+  private boolean conversationEnd = true;
 
   public SsmlDocumentBuilder() {
     this(Collections.emptyList());
@@ -247,6 +248,15 @@ public class SsmlDocumentBuilder {
   @Override
   public String toString() {
     return buildString();
+  }
+
+  public boolean isConversationEnd() {
+    return conversationEnd;
+  }
+
+  public SsmlDocumentBuilder conversationEnd(boolean conversationEnd) {
+    this.conversationEnd = conversationEnd;
+    return this;
   }
 
   private @NonNull String buildString() {

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceInput.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceInput.java
@@ -86,7 +86,7 @@ public interface VoiceInput {
    * 
    * @return The associated metadata, never null
    */
-  @NonNull JSONObject getMetadata();
+  @NonNull CommonMetadata getMetadata();
 
   /**
    * Get the message type with respect to a conversation flow.

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceInput.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceInput.java
@@ -22,8 +22,6 @@ package com.derpgroup.derpwizard.voice.model;
 
 import java.util.Map;
 
-import net.sf.json.JSONObject;
-
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceMessageFactory.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceMessageFactory.java
@@ -24,8 +24,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 
-import net.sf.json.JSONObject;
-
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**

--- a/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceMessageFactory.java
+++ b/voice-interface/src/main/java/com/derpgroup/derpwizard/voice/model/VoiceMessageFactory.java
@@ -86,13 +86,13 @@ public class VoiceMessageFactory {
    *          The voice interface type that sent the request, not null
    * @return A VoiceInput wrapper, never null
    */
-  public static @NonNull VoiceInput buildInputMessage(@NonNull Object request, @NonNull JSONObject metadata, @NonNull InterfaceType type) {
+  public static @NonNull VoiceInput buildInputMessage(@NonNull Object request, @NonNull CommonMetadata metadata, @NonNull InterfaceType type) {
     if (!INPUT_MAP.containsKey(type)) {
       throw new IllegalArgumentException("Invalid type: " + type);
     }
 
     try {
-      return (VoiceInput) INPUT_MAP.get(type).getConstructor(Object.class, JSONObject.class).newInstance(request, metadata);
+      return (VoiceInput) INPUT_MAP.get(type).getConstructor(Object.class, CommonMetadata.class).newInstance(request, metadata);
     } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
       throw new UnsupportedOperationException("Failed to build instance", e);
     }

--- a/voice-interface/src/test/java/com/derpgroup/derpwizard/voice/model/AlexaInputTest.java
+++ b/voice-interface/src/test/java/com/derpgroup/derpwizard/voice/model/AlexaInputTest.java
@@ -24,12 +24,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-
-import net.sf.json.JSONObject;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -102,7 +101,9 @@ public class AlexaInputTest {
   @Test
   public void constructorWithMetadata(){
     CommonMetadata metadata = new CommonMetadata();
-    Map<String, Object> conversationHistory = new HashMap<String,Object>();
+    ConversationHistoryEntry conversationHistoryEntry = new ConversationHistoryEntry();
+    List<ConversationHistoryEntry> conversationHistory = new ArrayList<ConversationHistoryEntry>();
+    conversationHistory.add(conversationHistoryEntry);
     metadata.setConversationHistory(conversationHistory);
 
     VoiceInput vi = new AlexaInput(intentRequest, metadata);

--- a/voice-interface/src/test/java/com/derpgroup/derpwizard/voice/model/AlexaInputTest.java
+++ b/voice-interface/src/test/java/com/derpgroup/derpwizard/voice/model/AlexaInputTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -100,16 +101,19 @@ public class AlexaInputTest {
 
   @Test
   public void constructorWithMetadata(){
-    JSONObject metadata = new JSONObject();
-    metadata.put("foo", "fooValue");
-    metadata.put("bar", 123);
+    CommonMetadata metadata = new CommonMetadata();
+    Map<String, Object> conversationHistory = new HashMap<String,Object>();
+    metadata.setConversationHistory(conversationHistory);
+    //JSONObject metadata = new JSONObject();
+    //metadata.put("foo", "fooValue");
+    //metadata.put("bar", 123);
 
     VoiceInput vi = new AlexaInput(intentRequest, metadata);
     assertNotNull(vi.getMetadata());
-    assertNotNull(vi.getMetadata().get("foo"));
-    assertNotNull(vi.getMetadata().get("bar"));
-    assertEquals(vi.getMetadata().get("foo"),metadata.get("foo"));
-    assertEquals(vi.getMetadata().get("bar"),metadata.get("bar"));
+    assertNotNull(vi.getMetadata().getConversationHistory());
+    //assertNotNull(vi.getMetadata().get("bar"));
+    //assertEquals(vi.getMetadata().get("foo"),metadata.get("foo"));
+    assertEquals(conversationHistory,vi.getMetadata().getConversationHistory());
   }
 
   @Test

--- a/voice-interface/src/test/java/com/derpgroup/derpwizard/voice/model/AlexaInputTest.java
+++ b/voice-interface/src/test/java/com/derpgroup/derpwizard/voice/model/AlexaInputTest.java
@@ -104,15 +104,10 @@ public class AlexaInputTest {
     CommonMetadata metadata = new CommonMetadata();
     Map<String, Object> conversationHistory = new HashMap<String,Object>();
     metadata.setConversationHistory(conversationHistory);
-    //JSONObject metadata = new JSONObject();
-    //metadata.put("foo", "fooValue");
-    //metadata.put("bar", 123);
 
     VoiceInput vi = new AlexaInput(intentRequest, metadata);
     assertNotNull(vi.getMetadata());
     assertNotNull(vi.getMetadata().getConversationHistory());
-    //assertNotNull(vi.getMetadata().get("bar"));
-    //assertEquals(vi.getMetadata().get("foo"),metadata.get("foo"));
     assertEquals(conversationHistory,vi.getMetadata().getConversationHistory());
   }
 


### PR DESCRIPTION
Dependent on #11 

There are some things here that I think are worth calling out.

First, when a new request comes into our manager, we want to drop it on the end of our conversation history as a conversation history entry.  One of the things we want to store is the metadata that was sent with the request, but we do not want to store the conversation history field (or else we'd end up with a giant ugly nested conversation history mess after a few calls).  Further, we need to make sure that at the end of our request, we only serialize the data that came in with the request - which is a problem because the metadata object is a live object being modified deeper in our code.  As a result, we need to clone the metadata object at this point.  The clone will be stored in our conversationHistory (minus its own conversationHistory child, per above), and the original object will now be free for the user to screw with.

Second, this is further complicated by the fact that our common metadata object is meant to be extended by different services.  Because the CommonMetadata object can't possibly know about the metadata fields of its implementing services, we need a way to dynamically deserialize into other types at runtime.  Jackson provides annotations to do this, but there was a little work on our side to allow it.  Specifically, this is where the Module comes in on AbstractManager - this allows the service to override the Module for ObjectMapper, describing whatever set of MixIn annotations necessary.

Finally, `@JsonIgnoreProperties` is used to avoid serializing the conversationHistory element _only when it is a child of ConversationHistoryEntry_.
